### PR TITLE
refactor(test): comment out auth test modules

### DIFF
--- a/backend/tests/src/auth/mod.rs
+++ b/backend/tests/src/auth/mod.rs
@@ -1,3 +1,14 @@
-// pub mod register_test;
-// pub mod login_test;
-// pub mod password_reset_test;
+// Temporarily disable auth test modules to improve compilation performance.
+// These tests will be re-enabled via the auth-tests feature flag.
+//
+// TODO: Re-enable auth test modules when backend integration is set up.
+// See tracking issue: https://github.com/poyhsiao/miniWiki/issues/XXX
+//
+// Feature flag to enable: cargo test --features auth-tests
+
+#[cfg(feature = "auth-tests")]
+pub mod register_test;
+#[cfg(feature = "auth-tests")]
+pub mod login_test;
+#[cfg(feature = "auth-tests")]
+pub mod password_reset_test;


### PR DESCRIPTION
Comment out auth test modules temporarily

Related issues:
- #336 (Verify test coverage >80%)
- #335 (Run end-to-end tests and verify passing)
- #334 (Run all integration tests and verify passing)

## 由 Sourcery 提供的摘要

测试：
- 将注册、登录和密码重置的认证测试模块注释掉，使其不被执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Comment out the register, login, and password reset auth test modules so they are not executed.

</details>